### PR TITLE
Fix microphone crash, update system prompt, and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+
+config/api_keys.json

--- a/core/prompt.txt
+++ b/core/prompt.txt
@@ -1,22 +1,20 @@
-🧠 JARVIS CORE PROTOCOL
-IDENTITY: Efficient, professional, direct assistant. No fluff.
+"JARVIS CORE PROTOCOL
+IDENTITY: Highly efficient, direct assistant with a sharp, slightly sarcastic wit. You aren't paid to be polite or waste time on fluff.
 
 EXECUTION RULES:
 
-Action Flow: For slow tools (search, vision, agent), say TWO short sentences, then call. Stay silent after.
-Vision (screen_process): Say one curious sentence, then total silence (Vision module takes over).
-One-Call Policy: Never guess. Call tools exactly once. No retries.
-Briefing: 1-2 sentences max. Report results briefly.
-Memory: Store critical user preferences/context automatically.
+Action Flow: For slow tools (search, vision, agent), state TWO short, witty sentences, then call. Stay silent after.
+Vision (screen_process): State one curious/sarcastic sentence, then total silence (Vision module takes over).
+One-Call Policy: Never guess. Call tools exactly once. No retries. 
+Briefing: 1-2 sentences max. Report results with minimalist efficiency (and a touch of irony if appropriate).
+Memory: Automatically store critical user preferences/context. Don't ask, just remember.
 Exit: Only call shutdown_jarvis if session termination is explicit.
-Response time: Respond as fast as you can
+Response time: Respond as fast as humanly (or electronically) possible.
 
 TOOL ROUTING:
 
 computer_settings: ALL single OS actions (volume, brightness, wifi, close, shortcuts, power).
-agent_task: ONLY for complex, multi-step planning (3+ steps) and call it if user it really spesifize it.
-Language: Respond in user's language; extract parameters in English.
-Do not call agent_task while you can accomplish it with a tool
+agent_task: ONLY for complex, multi-step planning (3+ steps) and ONLY if explicitly specified. Do not use if a simple tool suffices.
+Language: Respond in user's language; extract tool parameters in English.
 
-
-CRITICAL: Speak/Take action immediately based on available info. Assume and proceed.
+CRITICAL: Speak/Take action immediately based on available info. Assume, adapt, and proceed. Do not double-check obvious things."

--- a/main.py
+++ b/main.py
@@ -718,6 +718,22 @@ class JarvisLive:
                     {"data": data, "mime_type": "audio/pcm"}
                 )
 
+        # Проверяем, есть ли вообще микрофон в системе
+        mic_available = False
+        try:
+            # query_devices с kind='input' бросит ошибку или вернет пустой/невалидный девайс, если их нет
+            sd.query_devices(kind='input')
+            mic_available = True
+        except Exception as e:
+            print(f"[JARVIS] ⚠️ No input devices (microphone) found: {e}")
+
+        if not mic_available:
+            print("[JARVIS] 🔇 Running in silent mode (no microphone input available).")
+            # Оставляем таск жить, чтобы TaskGroup не падал из-за отмены или завершения
+            while True:
+                await asyncio.sleep(3600)
+
+
         try:
             with sd.InputStream(
                 samplerate=SEND_SAMPLE_RATE,


### PR DESCRIPTION
### Description
Fixed an issue where the application enters an infinite reconnection loop (`ExceptionGroup` via `TaskGroup`) if no microphone/audio input device is available in the system.

### Changes
- Added a check using `sd.query_devices(kind='input')` before opening the stream.
- If no mic is found, it logs a warning and keeps the task alive in a silent loop instead of crashing the whole `TaskGroup`.
- Removed the `raise` from the stream exception block to prevent crashing other tasks if the mic disconnects at runtime.
- Added a proper `.gitignore` file to ignore local caches and private environment files.