### PR TITLE
fix: reuse persistent browser tab in Playwright profiles

### DIFF
--- a/actions/browser_control.py
+++ b/actions/browser_control.py
@@ -20,6 +20,21 @@ from playwright.async_api import (
 )
 _OS = platform.system()   # "Windows" | "Darwin" | "Linux"
 
+def _first_usable_page(context: BrowserContext) -> Optional[Page]:
+    """Persistent browser profiles often already have a tab — avoid extra new_page()."""
+    for page in context.pages:
+        if page and not page.is_closed():
+            return page
+    return None
+
+
+async def _open_page(context: BrowserContext) -> Page:
+    existing = _first_usable_page(context)
+    if existing is not None:
+        return existing
+    return await context.new_page()
+
+
 def _normalize_url(url: str) -> str:
     """
     Bare words like "instagram" → "https://instagram.com"
@@ -444,8 +459,8 @@ class _BrowserSession:
                 Path(jarvis).mkdir(parents=True, exist_ok=True)
                 self._context = await engine_obj.launch_persistent_context(jarvis, **kwargs)
 
-            await asyncio.sleep(0.5)  
-            self._page = await self._context.new_page()
+            await asyncio.sleep(0.5)
+            self._page = await _open_page(self._context)
             print(f"[Browser] ✅ Firefox launched")
             return
 
@@ -460,7 +475,7 @@ class _BrowserSession:
             }
             self._context = await engine_obj.launch_persistent_context(safari_profile, **kwargs)
             await asyncio.sleep(0.5)
-            self._page = await self._context.new_page()
+            self._page = await _open_page(self._context)
             print(f"[Browser] ✅ Safari launched")
             return
 
@@ -493,8 +508,8 @@ class _BrowserSession:
 
         try:
             self._context = await engine_obj.launch_persistent_context(profile, **kwargs)
-            await asyncio.sleep(0.5) 
-            self._page = await self._context.new_page()
+            await asyncio.sleep(0.5)
+            self._page = await _open_page(self._context)
             print(f"[Browser] ✅ Launched [{label}] profile={profile}")
             return
         except Exception as e:
@@ -507,7 +522,7 @@ class _BrowserSession:
         try:
             self._context = await engine_obj.launch_persistent_context(jarvis_profile, **kwargs)
             await asyncio.sleep(0.5)
-            self._page = await self._context.new_page()
+            self._page = await _open_page(self._context)
             print(f"[Browser] ✅ Launched [{label}] with JARVIS profile")
         except Exception as e2:
             raise RuntimeError(f"Could not launch {self.browser_name}: {e2}") from e2
@@ -517,7 +532,7 @@ class _BrowserSession:
         await self._launch()
         # If somehow page got closed, open a fresh one
         if self._page is None or self._page.is_closed():
-            self._page = await self._context.new_page()
+            self._page = await _open_page(self._context)
             await asyncio.sleep(0.2)
         return self._page
 

--- a/actions/screen_processor.py
+++ b/actions/screen_processor.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import io
 import json
+import os
 import re
 import sys
 import threading
@@ -152,7 +153,7 @@ def _detect_camera_index() -> int:
 
     backend = _cv2_backend()
     print("[Vision] 🔍 Auto-detecting camera...")
-    for idx in range(6):
+    for idx in range(10):
         if _probe_camera(idx, backend):
             print(f"[Vision] ✅ Camera found at index {idx}")
             _save_config_key("camera_index", idx)
@@ -165,6 +166,9 @@ def _detect_camera_index() -> int:
 
 
 def _get_camera_index() -> int:
+    env_idx = os.environ.get("JARVIS_CAMERA_INDEX", "").strip()
+    if env_idx.isdigit():
+        return int(env_idx)
     cfg = _load_config()
     if "camera_index" in cfg:
         return int(cfg["camera_index"])


### PR DESCRIPTION
## Summary

- Reuse the first open tab in a persistent Playwright context when navigating, instead of always calling `new_page()`.
- Add `JARVIS_CAMERA_INDEX` environment variable for webcam selection on multi-camera systems.

## Motivation

Addresses duplicate-tab / `BrowserContext.new_page` issues with persistent Playwright profiles ([#31](https://github.com/FatihMakes/Mark-XXXIX/issues/31)) and camera index selection ([#20](https://github.com/FatihMakes/Mark-XXXIX/issues/20)).

## Test plan

- [ ] Launch Jarvis with a persistent browser profile
- [ ] Open a URL twice — should reuse the same tab when possible
- [ ] Set `JARVIS_CAMERA_INDEX=1` and confirm webcam on multi-camera PCs
