### PR TITLE
Fix setup.py UnicodeEncodeError on Windows consoles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,11 @@ if platform.system() == "Windows":
     except ImportError:
         postinstall = Path(sys.executable).parent / "Scripts" / "pywin32_postinstall.py"
         print(
-            "\n⚠️  pywin32 did not install correctly — desktop shortcut creation "
+            "\nWARNING: pywin32 did not install correctly. Desktop shortcut creation "
             "will fall back to a slower method that may not work on this machine.\n"
             "    Try fixing it manually with:\n"
             f'    "{sys.executable}" -m pip install --force-reinstall pywin32\n'
             f'    "{sys.executable}" "{postinstall}" -install\n'
         )
 
-print("\n✅ Setup complete! Run 'python main.py' to start MARK L.")
-
+print("\nSetup complete! Run 'python main.py' to start MARK L.")


### PR DESCRIPTION
## Why
Running `python setup.py` could crash on Windows cp1252 terminals when `pywin32` import failed, because the warning and success messages used non-ASCII characters that the console encoding could not print.

## What changed
This updates `setup.py` to use ASCII-only warning and success strings. The behavior is unchanged: setup still installs requirements, installs Playwright browsers, and prints recovery steps if `pywin32` is not importable.

## Notes
This is a compatibility fix for Windows console encoding only; no runtime tool logic was changed.